### PR TITLE
Expand glass utilities and document Tailwind layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <h1 align="center">water</h1>
 <p align="left">
-  Liquid-Glass utilities &amp; tokens for Tailwind CSS v4.  
+  Liquid-Glass utilities &amp; tokens for Tailwind CSS v4.
   One preset &nbsp;—&nbsp; works in **React, Vue, Svelte, Astro, plain HTML** (anything that runs Tailwind).
 </p>
 
@@ -16,6 +16,7 @@
 | What you get | Class | CSS cost |
 |--------------|-------|----------|
 | GPU-blurred, saturated “glass” panel | `.glass` | backdrop-blur + edge sheen |
+| Glass variants: size + texture | `.glass-sm`, `.glass-lg`, `.glass-noise`, `.glass-sheen` | tweak blur & overlays |
 | Widget block (no blur, axial gradient) | `.widget` | dual-tone gradient + rim |
 | Icon / tile with dual rim | `.tile` | razor rim + inner glow |
 | Design tokens | `--glass-*`, `--widget-*` | tweak in one place |
@@ -30,3 +31,12 @@ No React dependency, no JS bundles, < **3 kB** minified.
 bun add -D @your-scope/glass-preset      # bun
 # npm  install -D @your-scope/glass-preset
 # pnpm add  -D @your-scope/glass-preset
+```
+
+## 💡 Usage
+
+```html
+<div class="glass glass-lg glass-noise p-6">
+  <!-- content -->
+</div>
+```

--- a/src/index.css
+++ b/src/index.css
@@ -1,146 +1,177 @@
 @import "tailwindcss";
 @import "./theme.css" layer(theme);
 
-:root {
-  --primary: #343d46;
-  --primary-light: #434C5B;
-  --secondary: #0c111c;
-  --secondary-light: #0c141c;
-  --background: #070a0e;
-  --background-other: #00070e;
-  --bubblebackground: #14151c;
-  --card-background: #0a0e13;
-  --card: #18191b;
-  --text: #e3e7ee;
-  --text-secondary: #b7becb;
-  --text-muted: #6b7280;
-  --gray-50: #f9fafb;
-  --gray-100: #f3f4f6;
-  --gray-200: #e5e7eb;
-  --gray-300: #d1d5db;
-  --gray-400: #9ca3af;
-  --gray-500: #6b7280;
-  --gray-600: #4b5563;
-  --gray-700: #374151;
-  --gray-800: #1f2937;
-  --gray-900: #111827;
-  --success: #63ba83;
-  --warning: #e2cc5f;
-  --danger: #8f2a2a;
-  --body-text-size: 0.925rem;
-}
+@layer base {
+  :root {
+    --primary: #343d46;
+    --primary-light: #434C5B;
+    --secondary: #0c111c;
+    --secondary-light: #0c141c;
+    --background: #070a0e;
+    --background-other: #00070e;
+    --bubblebackground: #14151c;
+    --card-background: #0a0e13;
+    --card: #18191b;
+    --text: #e3e7ee;
+    --text-secondary: #b7becb;
+    --text-muted: #6b7280;
+    --gray-50: #f9fafb;
+    --gray-100: #f3f4f6;
+    --gray-200: #e5e7eb;
+    --gray-300: #d1d5db;
+    --gray-400: #9ca3af;
+    --gray-500: #6b7280;
+    --gray-600: #4b5563;
+    --gray-700: #374151;
+    --gray-800: #1f2937;
+    --gray-900: #111827;
+    --success: #63ba83;
+    --warning: #e2cc5f;
+    --danger: #8f2a2a;
+    --body-text-size: 0.925rem;
+  }
 
-body {
-  background-color: var(--background);
-  color: var(--text);
-}
-
-/* iPhone-style card with rounded corners */
-.card {
-  background-color: var(--card-background);
-  border-radius: 16px;
-  padding: 12px;
-  margin-bottom: 12px;
-}
-
-/* Progress bar styling */
-.progress-bar {
-  height: 4px;
-  border-radius: 2px;
-  background-color: #333333;
-  overflow: hidden;
-}
-
-.progress-bar-fill {
-  height: 100%;
-  background-color: var(--primary);
-}
-
-/* iPhone-style navigation items */
-.bottom-nav-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-secondary);
-  font-size: 0.75rem;
-}
-
-.bottom-nav-item.active {
-  color: var(--text);
-}
-
-/* Chat message styling */
-.chat-bubble{
-  box-sizing: border-box;
-  border-radius: 1.25rem;
-  margin-bottom: 12px;
-  max-width: 90%;
-  font-size: var(--body-text-size);
-  font-weight: 200;
-  padding: 10px 14px;
-}
-
-.chat-bubble.ai {
-  background-color: var(--bubblebackground);
-  color: var(--text);
-  outline: 1px solid var(--primary);
-  margin-right: auto;
-}
-
-.chat-bubble.user {
-  background-color: var(--primary);
-  color: var(--text);
-  margin-left: auto;
-}
-
-button, input, textarea, select {
-  border-radius: 1.25rem;
-  font-size: 0.875rem;
-  font-weight: 200;
-}
-
-/* Prevent mobile zoom on input focus */
-@media screen and (max-width: 767px) {
-  input, textarea, select {
-    font-size: 16px !important;
+  body {
+    background-color: var(--background);
+    color: var(--text);
   }
 }
 
-/* Custom focus styling for inputs */
-input:focus, textarea:focus, select:focus {
-  outline: none;
-  border-color: var(--text-muted);
-  box-shadow: 0 0 0 2px rgba(107, 114, 128, 0.2);
+@layer components {
+  /* iPhone-style card with rounded corners */
+  .card {
+    background-color: var(--card-background);
+    border-radius: 16px;
+    padding: 12px;
+    margin-bottom: 12px;
+  }
+
+  /* Progress bar styling */
+  .progress-bar {
+    height: 4px;
+    border-radius: 2px;
+    background-color: #333333;
+    overflow: hidden;
+  }
+
+  .progress-bar-fill {
+    height: 100%;
+    background-color: var(--primary);
+  }
+
+  /* iPhone-style navigation items */
+  .bottom-nav-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+  }
+
+  .bottom-nav-item.active {
+    color: var(--text);
+  }
+
+  /* Chat message styling */
+  .chat-bubble {
+    box-sizing: border-box;
+    border-radius: 1.25rem;
+    margin-bottom: 12px;
+    max-width: 90%;
+    font-size: var(--body-text-size);
+    font-weight: 200;
+    padding: 10px 14px;
+  }
+
+  .chat-bubble.ai {
+    background-color: var(--bubblebackground);
+    color: var(--text);
+    outline: 1px solid var(--primary);
+    margin-right: auto;
+  }
+
+  .chat-bubble.user {
+    background-color: var(--primary);
+    color: var(--text);
+    margin-left: auto;
+  }
+
+  button,
+  input,
+  textarea,
+  select {
+    border-radius: 1.25rem;
+    font-size: 0.875rem;
+    font-weight: 200;
+  }
+
+  @media screen and (max-width: 767px) {
+    input,
+    textarea,
+    select {
+      font-size: 16px !important;
+    }
+  }
+
+  input:focus,
+  textarea:focus,
+  select:focus {
+    outline: none;
+    border-color: var(--text-muted);
+    box-shadow: 0 0 0 2px rgba(107, 114, 128, 0.2);
+  }
 }
 
-/*  Utility layer  */
-@layer utilities {
-  .glass {
-    /* single GPU filter pass: blur ➜ saturate */
-    backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+@utility glass {
+  /* single GPU filter pass: blur ➜ saturate */
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 
-    /* dark translucent body */
-    background: var(--glass-fill);
+  /* dark translucent body */
+  background-color: var(--glass-fill);
+  background-image: var(--glass-texture);
+  background-blend-mode: overlay;
 
-    /* brighter edge + faint inner glow for "glassier" pop */
-    box-shadow:
-      inset 0 0   0 1px   var(--glass-edge),
-      inset 0 1px 4px 1px var(--glass-edge);
+  /* brighter edge + faint inner glow for "glassier" pop */
+  box-shadow:
+    inset 0 0   0 1px   var(--glass-edge),
+    inset 0 1px 4px 1px var(--glass-edge);
 
-    border-radius: .875rem; /* 14 px default */
-  }
+  border-radius: .875rem; /* 14 px default */
+}
 
-  /* ===  .widget (no blur, no saturate)  === */
-  .widget {
-    background:
-      linear-gradient(180deg,
-        var(--bubblebackground) 0%,
-        var(--secondary)   100%);
-        
-    border-color: var(--bubblebackground);
+@utility glass-sm {
+  @apply glass;
+  --glass-blur: var(--glass-blur-sm);
+  --glass-saturate: var(--glass-saturate-sm);
+}
 
-    border-radius: 1.25rem;  /* 20 px */
-    padding: 1rem;
-  }
+@utility glass-lg {
+  @apply glass;
+  --glass-blur: var(--glass-blur-lg);
+  --glass-saturate: var(--glass-saturate-lg);
+}
+
+@utility glass-noise {
+  --glass-texture: var(--glass-texture-noise);
+}
+
+@utility glass-sheen {
+  --glass-texture: var(--glass-texture-sheen);
+}
+
+/* ===  .widget (no blur, no saturate)  === */
+@utility widget {
+  background: linear-gradient(180deg, var(--widget-grad-start) 0%, var(--widget-grad-end) 100%);
+  border-color: var(--widget-grad-start);
+  border-radius: 1.25rem;  /* 20 px */
+  padding: 1rem;
+}
+
+@utility tile {
+  background-color: rgba(255 255 255 / .03);
+  box-shadow:
+    inset 0 0 0 1px var(--tile-edge),
+    inset 0 2px 4px 0 var(--tile-glow);
+  border-radius: .875rem;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,18 +1,31 @@
 @import "tailwindcss";
 
-
-@theme {/* spacing / radii */
+@theme {
+    /* spacing / radii */
     --space-3:   0.75rem;         /* 12 px  */
     --radius-4:  1rem;            /* 16 px  */
-    
+
     /*  Tailwind 4 tokens  */
     --glass-blur:       12px;                 /* tweak to taste */
     --glass-saturate:   140%;                 /* >100% = punchier colour */
     --glass-fill:       rgba(40 45 50 / 0.25);
     --glass-edge:       rgba(227 231 238 / .04);
-    
+
+    /* extra glass variant tokens */
+    --glass-blur-sm:     4px;
+    --glass-blur-lg:     20px;
+    --glass-saturate-sm: 120%;
+    --glass-saturate-lg: 180%;
+    --glass-texture: none;
+    --glass-texture-noise: repeating-linear-gradient(45deg, rgba(255 255 255 / .06) 0, rgba(255 255 255 / .06) 1px, transparent 1px, transparent 3px);
+    --glass-texture-sheen: linear-gradient(135deg, rgba(255 255 255 / .25) 0%, rgba(255 255 255 / 0) 60%);
+
     /* ===  Widget tokens (still always-dark)  === */
     --widget-grad-start:  rgba(19 22 35 / .72);      /* top */
     --widget-grad-end:    rgba(10 12 22 / .92);      /* bottom */
     --widget-edge:        rgba(255 255 255 / .2);   /* highlight rim */
+
+    /* tile tokens */
+    --tile-edge: rgba(255 255 255 / .1);
+    --tile-glow: rgba(0 0 0 / .3);
 }


### PR DESCRIPTION
## Summary
- restructure base and component styles into Tailwind 4 layers
- add glass variants for blur sizing and texture overlays
- introduce tile utility and document usage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897c285a19c832b859f3cc27601adbc